### PR TITLE
Fix typo in C# / Round 1 / FibonacciIndexer

### DIFF
--- a/csharp/ROUND_1/ROUND_1_B/src/FibonacciIndexer.cs
+++ b/csharp/ROUND_1/ROUND_1_B/src/FibonacciIndexer.cs
@@ -17,7 +17,7 @@ public class FibonacciIndexer
         int indexOfFibonacci = -1;
         int currentIndex = 2;
         long f = 0;
-        List<long> sequence = BuildInitialSequencce();
+        List<long> sequence = BuildInitialSequence();
         while (f < fibonacci)
         {
             f = sequence[currentIndex - 1] + sequence[currentIndex - 2];
@@ -30,7 +30,7 @@ public class FibonacciIndexer
         return indexOfFibonacci;
     }
 
-    private static List<long> BuildInitialSequencce()
+    private static List<long> BuildInitialSequence()
     {
         return [0, 1];
     }


### PR DESCRIPTION
Just a single typo: `FibonacciIndexer.BuildInitialSequence` contained the character `c` two times.